### PR TITLE
Add second animation curve option for modal bottom sheet

### DIFF
--- a/modal_bottom_sheet/example/pubspec.lock
+++ b/modal_bottom_sheet/example/pubspec.lock
@@ -72,6 +72,30 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.0"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   lints:
     dependency: "direct dev"
     description:
@@ -84,41 +108,41 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   modal_bottom_sheet:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "3.0.1"
+    version: "3.0.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -252,14 +276,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  web:
+  vm_service:
     dependency: transitive
     description:
-      name: web
-      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
+      name: vm_service
+      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "13.0.0"
 sdks:
-  dart: ">=3.2.0-194.0.dev <4.0.0"
+  dart: ">=3.3.0 <4.0.0"
   flutter: ">=3.13.0"

--- a/modal_bottom_sheet/lib/src/bottom_sheet.dart
+++ b/modal_bottom_sheet/lib/src/bottom_sheet.dart
@@ -36,6 +36,7 @@ class ModalBottomSheet extends StatefulWidget {
     super.key,
     required this.animationController,
     this.animationCurve,
+    this.secondAnimationCurve,
     this.enableDrag = true,
     this.containerBuilder,
     this.bounce = true,
@@ -68,6 +69,7 @@ class ModalBottomSheet extends StatefulWidget {
   ///
   /// If no curve is provided it falls back to `decelerateEasing`.
   final Curve? animationCurve;
+  final Curve? secondAnimationCurve;
 
   /// Allows the bottom sheet to  go beyond the top bound of the content,
   /// but then bounce the content back to the edge of
@@ -191,6 +193,7 @@ class ModalBottomSheetState extends State<ModalBottomSheet>
   }
 
   ParametricCurve<double> animationCurve = Curves.linear;
+  ParametricCurve<double> secondAnimationCurve = Curves.linear;
 
   void _handleDragUpdate(double primaryDelta) async {
     animationCurve = Curves.linear;
@@ -337,10 +340,12 @@ class ModalBottomSheetState extends State<ModalBottomSheet>
   }
 
   Curve get _defaultCurve => widget.animationCurve ?? _decelerateEasing;
+  Curve get _defaultSecondCurve => widget.secondAnimationCurve ?? _decelerateEasing;
 
   @override
   void initState() {
     animationCurve = _defaultCurve;
+    secondAnimationCurve = _defaultSecondCurve;
     _bounceDragController =
         AnimationController(vsync: this, duration: Duration(milliseconds: 300));
 
@@ -368,7 +373,7 @@ class ModalBottomSheetState extends State<ModalBottomSheet>
       animation: widget.animationController,
       builder: (context, Widget? child) {
         assert(child != null);
-        final animationValue = animationCurve.transform(
+        final animationValue = (_dismissUnderway && !isDragging ? secondAnimationCurve : animationCurve).transform(
           widget.animationController.value,
         );
 

--- a/modal_bottom_sheet/lib/src/bottom_sheet_route.dart
+++ b/modal_bottom_sheet/lib/src/bottom_sheet_route.dart
@@ -16,6 +16,7 @@ class _ModalBottomSheet<T> extends StatefulWidget {
     this.expanded = false,
     this.enableDrag = true,
     this.animationCurve,
+    this.secondAnimationCurve,
   });
 
   final double? closeProgressThreshold;
@@ -25,6 +26,7 @@ class _ModalBottomSheet<T> extends StatefulWidget {
   final bool enableDrag;
   final AnimationController? secondAnimationController;
   final Curve? animationCurve;
+  final Curve? secondAnimationCurve;
 
   @override
   _ModalBottomSheetState<T> createState() => _ModalBottomSheetState<T>();
@@ -112,6 +114,7 @@ class _ModalBottomSheetState<T> extends State<_ModalBottomSheet<T>> {
                 bounce: widget.bounce,
                 scrollController: scrollController,
                 animationCurve: widget.animationCurve,
+                secondAnimationCurve: widget.secondAnimationCurve,
               ),
             );
           },
@@ -136,6 +139,7 @@ class ModalSheetRoute<T> extends PageRoute<T> {
     required this.expanded,
     this.bounce = false,
     this.animationCurve,
+    this.secondAnimationCurve,
     Duration? duration,
     super.settings,
   })  : duration = duration ?? _bottomSheetDuration;
@@ -154,6 +158,7 @@ class ModalSheetRoute<T> extends PageRoute<T> {
 
   final AnimationController? secondAnimationController;
   final Curve? animationCurve;
+  final Curve? secondAnimationCurve;
 
   @override
   Duration get transitionDuration => duration;
@@ -204,6 +209,7 @@ class ModalSheetRoute<T> extends PageRoute<T> {
         bounce: bounce,
         enableDrag: enableDrag,
         animationCurve: animationCurve,
+        secondAnimationCurve: secondAnimationCurve,
       ),
     );
     return bottomSheet;
@@ -240,6 +246,7 @@ Future<T?> showCustomModalBottomSheet<T>({
   bool expand = false,
   AnimationController? secondAnimation,
   Curve? animationCurve,
+  Curve? secondAnimationCurve,
   bool useRootNavigator = false,
   bool isDismissible = true,
   bool enableDrag = true,
@@ -268,6 +275,7 @@ Future<T?> showCustomModalBottomSheet<T>({
     modalBarrierColor: barrierColor,
     enableDrag: enableDrag,
     animationCurve: animationCurve,
+    secondAnimationCurve: secondAnimationCurve,
     duration: duration,
     settings: settings,
     closeProgressThreshold: closeProgressThreshold,

--- a/modal_bottom_sheet/lib/src/bottom_sheets/material_bottom_sheet.dart
+++ b/modal_bottom_sheet/lib/src/bottom_sheets/material_bottom_sheet.dart
@@ -16,6 +16,7 @@ Future<T?> showMaterialModalBottomSheet<T>({
   bool expand = false,
   AnimationController? secondAnimation,
   Curve? animationCurve,
+  Curve? secondAnimationCurve,
   bool useRootNavigator = false,
   bool isDismissible = true,
   bool enableDrag = true,
@@ -45,6 +46,7 @@ Future<T?> showMaterialModalBottomSheet<T>({
     modalBarrierColor: barrierColor,
     enableDrag: enableDrag,
     animationCurve: animationCurve,
+    secondAnimationCurve: secondAnimationCurve,
     duration: duration,
     settings: settings,
   ));


### PR DESCRIPTION
This PR adds a new param `secondCurveAnimation` to explicitly define closing animation curve for bottom sheet.
Previously the closing animation was basically the same as `curveAnimation` but run in reverse from 1.0 to 0.0 which was not ideal with asymmetric animation curves.